### PR TITLE
This is a change to seemingly deal with a golang issue

### DIFF
--- a/scripts/run-unit-tests.ps1
+++ b/scripts/run-unit-tests.ps1
@@ -255,7 +255,7 @@ function Install-Golang {
 
 function Install-GoDependencies {
     $deps = @(
-        "github.com/Sirupsen/logrus",
+        "github.com/sirupsen/logrus",
         "github.com/antonholmquist/jason"
     )
     foreach($d in $deps) {


### PR DESCRIPTION
https://github.com/golang/go/issues/26208
After rebuilding our windows 10 image, we are encountering the following failures on:
public-dcos-go-windows jenkins test
go: finding github.com/Sirupsen/logrus v1.3.0
go: github.com/Sirupsen/logrus@v1.3.0: parsing go.mod: unexpected module path "github.com/sirupsen/logrus"
go: error loading module requirements
Failed to install github.com/Sirupsen/logrus